### PR TITLE
Remove license classifer deprecated by PEP 639

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 4 - Beta
     Framework :: Hypothesis
     Intended Audience :: Developers
-    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/774